### PR TITLE
Fixed endorse banner not changing until refresh

### DIFF
--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -93,6 +93,7 @@ define('forum/topic/events', [
         $('[data-pid="' + data.post.pid + '"] .endorseBtn').filter(function (index, el) {
             return parseInt($(el).closest('[data-pid]').attr('data-pid'), 10) === parseInt(data.post.pid, 10);
         }).html(data.isEndorsed ? 'Unendorse' : 'Endorse').attr('data-endorsed', data.isEndorsed);
+        ajaxify.refresh();
     }
 
     function onTopicPurged(data) {


### PR DESCRIPTION
Previously, the endorsed banner above a post only showed itself or hides from the button press after a refresh. It now shows or hides immediately using ajaxify.

Resolves https://github.com/CMU-313/spring23-nodebb-team-hecl-io/issues/76