### PR TITLE
Unit tests for endorse feature

### DIFF
--- a/test/posts.js
+++ b/test/posts.js
@@ -302,6 +302,22 @@ describe('Post\'s', () => {
         });
     });
 
+    describe('endorsing', () => {
+        it('should endorse a post', async () => {
+            const data = await apiPosts.endorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
+            assert.equal(data.isEndorsed, true);
+            const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
+            assert.equal(hasEndorsed, true);
+        });
+
+        it('should unendorse a post', async () => {
+            const data = await apiPosts.unendorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
+            assert.equal(data.isEndorsed, false);
+            const hasEndorsed = await posts.hasEndorsed([postData.pid], voterUid);
+            assert.equal(hasEndorsed[0], false);
+        });
+    });
+
     describe('post tools', () => {
         it('should error if data is invalid', (done) => {
             socketPosts.loadPostTools({ uid: globalModUid }, null, (err) => {


### PR DESCRIPTION
Added unit tests in the testing directory for the endorse feature. These check the API by trying to endorse or unendorse a post.

Resolves https://github.com/CMU-313/spring23-nodebb-team-hecl-io/issues/80